### PR TITLE
Wrap correctly on small width

### DIFF
--- a/src/gui/NoteList/NoteList.tsx
+++ b/src/gui/NoteList/NoteList.tsx
@@ -20,9 +20,11 @@ import {
 } from "react-icons/fa6";
 
 const ButtonBarContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  gap: 1rem;
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: space-evenly;
 `;
 
 const DateButtonBar = styled(ButtonBar)`


### PR DESCRIPTION
Hello @rsandz ,
I usually keep the plugin panel on a small sidebar, and when viewing it on smaller screen it makes quite difficult to manage the bottom buttons.

This PR take advantage of a few flex attributes to improve the layout on very small widths. Otherwise it makes no difference.

Before:

|Before|After|
|-|-|
|<img width="216" alt="Schermata 2024-03-07 alle 21 34 37" src="https://github.com/rsandz/joplin-calendar/assets/6209647/63ea9dcd-ccc9-4968-9b04-eff95b19762f">|<img width="222" alt="Schermata 2024-03-07 alle 22 12 08" src="https://github.com/rsandz/joplin-calendar/assets/6209647/455148d6-df29-4b8c-9156-8a6d34c5c5e4">|


Thank you.